### PR TITLE
Updated submit binary

### DIFF
--- a/CrashlyticsFramework.podspec
+++ b/CrashlyticsFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CrashlyticsFramework"
-  s.version      = “2.2.6”
+  s.version      = "2.2.5"
   s.summary      = "The most powerful, yet lightest weight crash reporting solution for iOS and Android developers. | Crashlytics"
   s.homepage     = "http://crashlytics.com"
   s.license      = { 


### PR DESCRIPTION
I put the Podspec version to 2.2.6, although it's not exactly correct. Not sure how we could use another version number because it does not follow Crashlytics number.

The submit tool is behind and that causes problem with pushing betas.
